### PR TITLE
fix for curl character limitation

### DIFF
--- a/cucumberJenkinsExecuteShell.sh
+++ b/cucumberJenkinsExecuteShell.sh
@@ -2,18 +2,15 @@
 
 cd "$WORKSPACE/target"
 
-#Read in file
-logs=$(<cucumber-report.json)
-echo "$logs"
+#Read in file, writing payload to a consolidated file to bypass curl character limitations in direct payload
+echo '{ "test-cycle" : $YOUR_QTEST_TEST_CYCLE_ID_HERE, "result" : ' > payload.json
+cat $YOUR_RESULTS_FILENAME_HERE >> payload.json
+echo ', "projectId" : $YOUR_QTEST_PROJECT_ID_HERE }' >> payload.json
 
 curl -X POST \
   $YOUR_PULSE_RULE_EVENT_URL \
   -H 'cache-control: no-cache' \
   -H 'content-type: application/json' \
-  -d '{
-    "test-cycle" : $YOUR_TEST_CYCLE_ID,
-    "result" : '"$logs"',
-    "projectId" : $YOUR_PROJECT_ID
-}'
+  -d @payload.json
 
 echo $WORKSPACE


### PR DESCRIPTION
This change will bypass the character limitation on curl payloads by attaching a file as the payload instead.  This will fix issues with embedded encoded image files of a size greater than said limitation.

Resolves this error message: **line 5: /usr/bin/curl: Argument list too long**